### PR TITLE
BLS Crypto Primitives

### DIFF
--- a/libraries/eosiolib/capi/eosio/crypto_bls_ext.h
+++ b/libraries/eosiolib/capi/eosio/crypto_bls_ext.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "types.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((eosio_wasm_import))
+void bls_g1_add(const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* res, uint32_t res_len);
+
+__attribute__((eosio_wasm_import))
+void bls_g2_add(const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* res, uint32_t res_len);
+
+__attribute__((eosio_wasm_import))
+void bls_g1_mul(const char* point, uint32_t point_len, const char* scalar, uint32_t scalar_len, char* res, uint32_t res_len);
+
+__attribute__((eosio_wasm_import))
+void bls_g2_mul(const char* point, uint32_t point_len, const char* scalar, uint32_t scalar_len, char* res, uint32_t res_len);
+
+__attribute__((eosio_wasm_import))
+void bls_g1_exp(const char* points, uint32_t points_len, const char* scalars, uint32_t scalars_len, uint32_t n, char* res, uint32_t res_len);
+
+__attribute__((eosio_wasm_import))
+void bls_g2_exp(const char* points, uint32_t points_len, const char* scalars, uint32_t scalars_len, uint32_t n, char* res, uint32_t res_len);
+
+__attribute__((eosio_wasm_import))
+void bls_pairing(const char* g1_points, uint32_t g1_points_len, const char* g2_points, uint32_t g2_points_len, uint32_t n, char* res, uint32_t res_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libraries/eosiolib/capi/eosio/crypto_bls_ext.h
+++ b/libraries/eosiolib/capi/eosio/crypto_bls_ext.h
@@ -25,6 +25,12 @@ void bls_g2_exp(const char* points, uint32_t points_len, const char* scalars, ui
 __attribute__((eosio_wasm_import))
 void bls_pairing(const char* g1_points, uint32_t g1_points_len, const char* g2_points, uint32_t g2_points_len, uint32_t n, char* res, uint32_t res_len);
 
+__attribute__((eosio_wasm_import))
+void bls_g1_map(const char* e, uint32_t e_len, char* res, uint32_t res_len);
+
+__attribute__((eosio_wasm_import))
+void bls_g2_map(const char* e, uint32_t e_len, char* res, uint32_t res_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/eosiolib/capi/eosio/crypto_bls_ext.h
+++ b/libraries/eosiolib/capi/eosio/crypto_bls_ext.h
@@ -31,6 +31,9 @@ void bls_g1_map(const char* e, uint32_t e_len, char* res, uint32_t res_len);
 __attribute__((eosio_wasm_import))
 void bls_g2_map(const char* e, uint32_t e_len, char* res, uint32_t res_len);
 
+__attribute__((eosio_wasm_import))
+void bls_fp_mod(const char* s, uint32_t s_len, char* res, uint32_t res_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/eosiolib/capi/eosio/types.h
+++ b/libraries/eosiolib/capi/eosio/types.h
@@ -66,4 +66,32 @@ struct ALIGNED(capi_checksum512) {
    uint8_t hash[64];
 };
 
+/**
+ * BLS12-381 scalar type (LE)
+ */
+struct ALIGNED(capi_bls_scalar) {
+   uint8_t data[32];
+};
+
+/**
+ * BLS12-381 G1 type (Jacobian, LE)
+ */
+struct ALIGNED(capi_bls_g1) {
+   uint8_t data[144];
+};
+
+/**
+ * BLS12-381 G2 type (Jacobian, LE)
+ */
+struct ALIGNED(capi_bls_g2) {
+   uint8_t data[288];
+};
+
+/**
+ * BLS12-381 GT type (LE)
+ */
+struct ALIGNED(capi_bls_gt) {
+   uint8_t data[576];
+};
+
 /// @}

--- a/libraries/eosiolib/capi/eosio/types.h
+++ b/libraries/eosiolib/capi/eosio/types.h
@@ -74,6 +74,20 @@ struct ALIGNED(capi_bls_scalar) {
 };
 
 /**
+ * BLS12-381 fp type (LE)
+ */
+struct ALIGNED(capi_bls_fp) {
+   uint8_t data[48];
+};
+
+/**
+ * BLS12-381 fp2 type (LE)
+ */
+struct ALIGNED(capi_bls_fp2) {
+   uint8_t data[96];
+};
+
+/**
  * BLS12-381 G1 type (Jacobian, LE)
  */
 struct ALIGNED(capi_bls_g1) {

--- a/libraries/eosiolib/core/eosio/crypto_bls_ext.hpp
+++ b/libraries/eosiolib/core/eosio/crypto_bls_ext.hpp
@@ -44,6 +44,9 @@ namespace eosio {
 
             __attribute__((eosio_wasm_import))
             void bls_g2_map(const char* e, uint32_t e_len, char* res, uint32_t res_len);
+
+            __attribute__((eosio_wasm_import))
+            void bls_fp_mod(const char* s, uint32_t s_len, char* res, uint32_t res_len);
         }
     }
 
@@ -93,5 +96,10 @@ namespace eosio {
     void bls_g2_map(const bls_fp2& e, bls_g2& res)
     {
         return internal_use_do_not_use::bls_g2_map(reinterpret_cast<const char*>(e.data()), e.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+
+    void bls_fp_mod(const std::array<uint8_t, 64>& s, bls_fp& res)
+    {
+        return internal_use_do_not_use::bls_fp_mod(reinterpret_cast<const char*>(s.data()), s.size(), reinterpret_cast<char*>(res.data()), res.size());
     }
 }

--- a/libraries/eosiolib/core/eosio/crypto_bls_ext.hpp
+++ b/libraries/eosiolib/core/eosio/crypto_bls_ext.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "fixed_bytes.hpp"
+#include "varint.hpp"
+#include "serialize.hpp"
+
+#include <array>
+#include <vector>
+
+namespace eosio {
+
+    using bls_scalar    = std::array<uint8_t, 32>;
+    using bls_g1        = std::array<uint8_t, 144>;
+    using bls_g2        = std::array<uint8_t, 288>;
+    using bls_gt        = std::array<uint8_t, 576>;
+
+    namespace internal_use_do_not_use {
+        extern "C" {
+            __attribute__((eosio_wasm_import))
+            void bls_g1_add(const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* res, uint32_t res_len);
+
+            __attribute__((eosio_wasm_import))
+            void bls_g2_add(const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* res, uint32_t res_len);
+
+            __attribute__((eosio_wasm_import))
+            void bls_g1_mul(const char* point, uint32_t point_len, const char* scalar, uint32_t scalar_len, char* res, uint32_t res_len);
+
+            __attribute__((eosio_wasm_import))
+            void bls_g2_mul(const char* point, uint32_t point_len, const char* scalar, uint32_t scalar_len, char* res, uint32_t res_len);
+
+            __attribute__((eosio_wasm_import))
+            void bls_g1_exp(const char* points, uint32_t points_len, const char* scalars, uint32_t scalars_len, uint32_t n, char* res, uint32_t res_len);
+
+            __attribute__((eosio_wasm_import))
+            void bls_g2_exp(const char* points, uint32_t points_len, const char* scalars, uint32_t scalars_len, uint32_t n, char* res, uint32_t res_len);
+
+            __attribute__((eosio_wasm_import))
+            void bls_pairing(const char* g1_points, uint32_t g1_points_len, const char* g2_points, uint32_t g2_points_len, uint32_t n, char* res, uint32_t res_len);
+        }
+    }
+
+    void bls_g1_add(const bls_g1& op1, const bls_g1& op2, bls_g1& res)
+    {
+        return internal_use_do_not_use::bls_g1_add(reinterpret_cast<const char*>(op1.data()), op1.size(), reinterpret_cast<const char*>(op2.data()), op2.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+
+    void bls_g2_add(const bls_g2& op1, const bls_g2& op2, bls_g2& res)
+    {
+        return internal_use_do_not_use::bls_g2_add(reinterpret_cast<const char*>(op1.data()), op1.size(), reinterpret_cast<const char*>(op2.data()), op2.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+
+    void bls_g1_mul(const bls_g1& point, const bls_scalar& scalar, bls_g1& res)
+    {
+        return internal_use_do_not_use::bls_g1_mul(reinterpret_cast<const char*>(point.data()), point.size(), reinterpret_cast<const char*>(scalar.data()), scalar.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+
+    void bls_g2_mul(const bls_g2& point, const bls_scalar& scalar, bls_g2& res)
+    {
+        return internal_use_do_not_use::bls_g2_mul(reinterpret_cast<const char*>(point.data()), point.size(), reinterpret_cast<const char*>(scalar.data()), scalar.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+
+    void bls_g1_exp(const std::vector<bls_g1>& points, const std::vector<bls_scalar>& scalars, bls_g1& res)
+    {
+        if(points.size() != scalars.size()) return;
+        return internal_use_do_not_use::bls_g1_exp(reinterpret_cast<const char*>(points.data()), points.size() * sizeof(bls_g1), reinterpret_cast<const char*>(scalars.data()), scalars.size() * sizeof(bls_scalar), points.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+
+    void bls_g2_exp(const std::vector<bls_g2>& points, const std::vector<bls_scalar>& scalars, bls_g2& res)
+    {
+        if(points.size() != scalars.size()) return;
+        return internal_use_do_not_use::bls_g2_exp(reinterpret_cast<const char*>(points.data()), points.size() * sizeof(bls_g2), reinterpret_cast<const char*>(scalars.data()), scalars.size() * sizeof(bls_scalar), points.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+
+    void bls_pairing(const std::vector<bls_g1>& g1_points, const std::vector<bls_g2>& g2_points, bls_gt& res)
+    {
+        if(g1_points.size() != g2_points.size()) return;
+        return internal_use_do_not_use::bls_pairing(reinterpret_cast<const char*>(g1_points.data()), g1_points.size() * sizeof(bls_g1), reinterpret_cast<const char*>(g2_points.data()), g2_points.size() * sizeof(bls_g2), g1_points.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+}

--- a/libraries/eosiolib/core/eosio/crypto_bls_ext.hpp
+++ b/libraries/eosiolib/core/eosio/crypto_bls_ext.hpp
@@ -10,6 +10,8 @@
 namespace eosio {
 
     using bls_scalar    = std::array<uint8_t, 32>;
+    using bls_fp        = std::array<uint8_t, 48>;
+    using bls_fp2       = std::array<uint8_t, 96>;
     using bls_g1        = std::array<uint8_t, 144>;
     using bls_g2        = std::array<uint8_t, 288>;
     using bls_gt        = std::array<uint8_t, 576>;
@@ -36,6 +38,12 @@ namespace eosio {
 
             __attribute__((eosio_wasm_import))
             void bls_pairing(const char* g1_points, uint32_t g1_points_len, const char* g2_points, uint32_t g2_points_len, uint32_t n, char* res, uint32_t res_len);
+
+            __attribute__((eosio_wasm_import))
+            void bls_g1_map(const char* e, uint32_t e_len, char* res, uint32_t res_len);
+
+            __attribute__((eosio_wasm_import))
+            void bls_g2_map(const char* e, uint32_t e_len, char* res, uint32_t res_len);
         }
     }
 
@@ -75,5 +83,15 @@ namespace eosio {
     {
         if(g1_points.size() != g2_points.size()) return;
         return internal_use_do_not_use::bls_pairing(reinterpret_cast<const char*>(g1_points.data()), g1_points.size() * sizeof(bls_g1), reinterpret_cast<const char*>(g2_points.data()), g2_points.size() * sizeof(bls_g2), g1_points.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+
+    void bls_g1_map(const bls_fp& e, bls_g1& res)
+    {
+        return internal_use_do_not_use::bls_g1_map(reinterpret_cast<const char*>(e.data()), e.size(), reinterpret_cast<char*>(res.data()), res.size());
+    }
+
+    void bls_g2_map(const bls_fp2& e, bls_g2& res)
+    {
+        return internal_use_do_not_use::bls_g2_map(reinterpret_cast<const char*>(e.data()), e.size(), reinterpret_cast<char*>(res.data()), res.size());
     }
 }

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -981,3 +981,8 @@ void bls_g2_map(const char* e, uint32_t e_len, char* res, uint32_t res_len)
 {
     intrinsics::get().call<intrinsics::bls_g2_map>(e, e_len, res, res_len);
 }
+
+void bls_fp_mod(const char* s, uint32_t s_len, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_fp_mod>(s, s_len, res, res_len);
+}

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -936,3 +936,38 @@ int32_t mod_exp( const char* base, uint32_t base_len, const char* exp, uint32_t 
 void sha3( const char* data, uint32_t data_len, char* hash, uint32_t hash_len, int32_t keccak ) {
    intrinsics::get().call<intrinsics::sha3>(data, data_len, hash, hash_len, keccak);
 }
+
+void bls_g1_add(const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_g1_add>(op1, op1_len, op2, op2_len, res, res_len);
+}
+
+void bls_g2_add(const char* op1, uint32_t op1_len, const char* op2, uint32_t op2_len, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_g2_add>(op1, op1_len, op2, op2_len, res, res_len);
+}
+
+void bls_g1_mul(const char* point, uint32_t point_len, const char* scalar, uint32_t scalar_len, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_g1_mul>(point, point_len, scalar, scalar_len, res, res_len);
+}
+
+void bls_g2_mul(const char* point, uint32_t point_len, const char* scalar, uint32_t scalar_len, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_g2_mul>(point, point_len, scalar, scalar_len, res, res_len);
+}
+
+void bls_g1_exp(const char* points, uint32_t points_len, const char* scalars, uint32_t scalars_len, uint32_t n, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_g1_exp>(points, points_len, scalars, scalars_len, n, res, res_len);
+}
+
+void bls_g2_exp(const char* points, uint32_t points_len, const char* scalars, uint32_t scalars_len, uint32_t n, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_g2_exp>(points, points_len, scalars, scalars_len, n, res, res_len);
+}
+
+void bls_pairing(const char* g1_points, uint32_t g1_points_len, const char* g2_points, uint32_t g2_points_len, uint32_t n, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_pairing>(g1_points, g1_points_len, g1_points, g1_points_len, n, res, res_len);
+}

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -971,3 +971,13 @@ void bls_pairing(const char* g1_points, uint32_t g1_points_len, const char* g2_p
 {
     intrinsics::get().call<intrinsics::bls_pairing>(g1_points, g1_points_len, g1_points, g1_points_len, n, res, res_len);
 }
+
+void bls_g1_map(const char* e, uint32_t e_len, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_g1_map>(e, e_len, res, res_len);
+}
+
+void bls_g2_map(const char* e, uint32_t e_len, char* res, uint32_t res_len)
+{
+    intrinsics::get().call<intrinsics::bls_g2_map>(e, e_len, res, res_len);
+}

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -179,7 +179,9 @@ intrinsic_macro(bls_g1_mul) \
 intrinsic_macro(bls_g2_mul) \
 intrinsic_macro(bls_g1_exp) \
 intrinsic_macro(bls_g2_exp) \
-intrinsic_macro(bls_pairing)
+intrinsic_macro(bls_pairing) \
+intrinsic_macro(bls_g1_map) \
+intrinsic_macro(bls_g2_map)
 
 
 

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -181,7 +181,8 @@ intrinsic_macro(bls_g1_exp) \
 intrinsic_macro(bls_g2_exp) \
 intrinsic_macro(bls_pairing) \
 intrinsic_macro(bls_g1_map) \
-intrinsic_macro(bls_g2_map)
+intrinsic_macro(bls_g2_map) \
+intrinsic_macro(bls_fp_mod)
 
 
 

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -4,6 +4,7 @@
 #include <eosio/chain.h>
 #include <eosio/crypto.h>
 #include <eosio/crypto_ext.h>
+#include <eosio/crypto_bls_ext.h>
 #include <eosio/db.h>
 #include <eosio/permission.h>
 #include <eosio/print.h>
@@ -171,7 +172,14 @@ intrinsic_macro(k1_recover) \
 intrinsic_macro(alt_bn128_add) \
 intrinsic_macro(alt_bn128_mul) \
 intrinsic_macro(alt_bn128_pair) \
-intrinsic_macro(mod_exp)
+intrinsic_macro(mod_exp) \
+intrinsic_macro(bls_g1_add) \
+intrinsic_macro(bls_g2_add) \
+intrinsic_macro(bls_g1_mul) \
+intrinsic_macro(bls_g2_mul) \
+intrinsic_macro(bls_g1_exp) \
+intrinsic_macro(bls_g2_exp) \
+intrinsic_macro(bls_pairing)
 
 
 

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -467,7 +467,12 @@ struct generation_utils {
          {"capi_checksum512", "checksum512"},
          {"fixed_bytes_20", "checksum160"},
          {"fixed_bytes_32", "checksum256"},
-         {"fixed_bytes_64", "checksum512"}
+         {"fixed_bytes_64", "checksum512"},
+
+         {"capi_bls_scalar", "bls_scalar"},
+         {"capi_bls_g1", "bls_g1"},
+         {"capi_bls_g2", "bls_g2"},
+         {"capi_bls_gt", "bls_gt"}
       };
 
       auto ret = translation_table[t];
@@ -762,7 +767,11 @@ struct generation_utils {
          "symbol",
          "symbol_code",
          "asset",
-         "extended_asset"
+         "extended_asset",
+         "bls_scalar",
+         "bls_g1",
+         "bls_g2",
+         "bls_gt"
       };
       return builtins.count(_translate_type(t)) >= 1;
    }

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -470,6 +470,8 @@ struct generation_utils {
          {"fixed_bytes_64", "checksum512"},
 
          {"capi_bls_scalar", "bls_scalar"},
+         {"capi_bls_g1", "bls_fp"},
+         {"capi_bls_g2", "bls_fp2"},
          {"capi_bls_g1", "bls_g1"},
          {"capi_bls_g2", "bls_g2"},
          {"capi_bls_gt", "bls_gt"}
@@ -769,6 +771,8 @@ struct generation_utils {
          "asset",
          "extended_asset",
          "bls_scalar",
+         "bls_fp",
+         "bls_fp2",
          "bls_g1",
          "bls_g2",
          "bls_gt"


### PR DESCRIPTION
Added the following types to cdt:
```
capi_bls_scalar  = uint8_t data[32];
capi_bls_fp      = uint8_t data[48];
capi_bls_fp2     = uint8_t data[96];
capi_bls_g1      = uint8_t data[144];
capi_bls_g2      = uint8_t data[288];
capi_bls_gt      = uint8_t data[576];
```

Added the following intrinsics to cdt (https://eips.ethereum.org/EIPS/eip-2537):
```
bls_g1_add(capi_bls_g1 op1, capi_bls_g1 op2, capi_bls_g1 result);
bls_g2_add(capi_bls_g2 op1, capi_bls_g2 op2, capi_bls_g2 result);
bls_g1_mul(capi_bls_g1 point, capi_bls_scalar scalar, bls_g1 result);
bls_g2_mul(capi_bls_g2 point, capi_bls_scalar scalar, bls_g2 result);
bls_g1_exp(capi_bls_g1[] points, capi_bls_scalar[] scalars, capi_bls_g1 result);
bls_g2_exp(capi_bls_g2[] points, capi_bls_scalar[] scalars, capi_bls_g2 result);
bls_pairing(capi_bls_g1[] g1_points, capi_bls_g2[] g2_points, capi_bls_gt result);
bls_g1_map(capi_bls_fp e, capi_bls_g1 result);
bls_g2_map(capi_bls_fp2 e, capi_bls_g2 result);
bls_fp_mod(std::array<uint8_t, 64> s, capi_bls_fp result);
```

Check out [aggsigtest](https://github.com/mschoenebeck/aggsigtest) for a sample contract using those host functions.